### PR TITLE
Prevent VIPs to get kicked ONLY while joining

### DIFF
--- a/src/iJoshuaHD/VIPSlots.php
+++ b/src/iJoshuaHD/VIPSlots.php
@@ -36,7 +36,7 @@ class VIPSlots extends PluginBase implements Listener{
 	public function onPlayerKick(PlayerKickEvent $event){
 		$p = strtolower($event->getPlayer()->getName());
 		
-		if($this->vips->exists($p)){
+		if($this->vips->exists($p) and $event->getReason() === "server full"){
 			$event->setCancelled(true);
 		}
 		


### PR DESCRIPTION
This change made it possible to kick VIPs from the server by a command (For example), and prevent the "kick" ONLY when they're joining the server
